### PR TITLE
Spruced up README a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # php-multihash
 
-PHP implementation for jbenet's [multihash](https://github.com/jbenet/multihash).
+> PHP implementation for [@jbenet](//github.com/jbenet)'s multihash.
+
+This is an implementation of [multihash](https://github.com/multiformats/multihash), one of the [multiformats](//github.com/multiformats/multiformats), by [@Fil](//github.com/Fil). For other implementations or the spec, see [multihash](https://github.com/multiformats/multihash).
+
+## Install
 
 To make:
+
 - install composer.phar from [getcomposer.org/download/](https://getcomposer.org/download/)
 - run `php composer.phar install`
 
+## Contribute
+
+Contributions are welcome! Please check out [the issues](//github.com/multiformats/php-multihash).
+
+## License
+
+[MIT](LICENSE) © Fil.


### PR DESCRIPTION
Added @Fil contribution note, contribute, license section to README. Basically follows [standard-readme](//github.com/RichardLitt/standard-readme). It would be compliant if we had a Usage section - do you think you could write one, @Fil, on how to use this code?
